### PR TITLE
bazel: add dependency on a third-party library not built with Bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,3 +9,16 @@ bazel_dep(name = "catch2", version = "3.8.1")
 
 bazel_dep(name = "gazelle", version = "0.42.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)
+
+# Add direct HTTP archive dependency on a library that is not built with Bazel
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# the archive file is going to be extracted at build time and the `build_file`
+# is going to be placed at the output directory (bazel-geocpp/external/+_repo_rules+gcem)
+http_archive(
+    name = "gcem",
+    build_file = "//third_party/gcem:BUILD.bazel.gen",
+    sha256 = "8e71a9f5b62956da6c409dda44b483f98c4a98ae72184f3aa4659ae5b3462e61",
+    strip_prefix = "gcem-1.18.0",
+    urls = ["https://github.com/kthohr/gcem/archive/v1.18.0.tar.gz"],
+)

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ build:
 	bazel run //:buildifier
 	bazel run //:gazelle
 	bazel run //src/apps:main -- 3 4
-
+	bazel run //src/apps:math -- 1

--- a/src/apps/BUILD.bazel
+++ b/src/apps/BUILD.bazel
@@ -8,3 +8,11 @@ cc_binary(
         "//src/geometry:rectangle",
     ],
 )
+
+cc_binary(
+    name = "math",
+    srcs = ["math.cc"],
+    deps = [
+        "@gcem",
+    ],
+)

--- a/src/apps/math.cc
+++ b/src/apps/math.cc
@@ -1,0 +1,11 @@
+#include <iostream>
+
+// this comes from a third-party library: https://github.com/kthohr/gcem
+#include "gcem.hpp"
+
+int main(int argc, char *argv[]) {
+  double value = std::stod(argv[1]);
+  double result = gcem::cos(value);
+  std::cout << "The cos of " << value << " is: " << result << std::endl;
+  return 0;
+}

--- a/third_party/gcem/BUILD.bazel
+++ b/third_party/gcem/BUILD.bazel
@@ -1,0 +1,1 @@
+# this file needs to exist to mark third_party/gcem as a package

--- a/third_party/gcem/BUILD.bazel.gen
+++ b/third_party/gcem/BUILD.bazel.gen
@@ -1,0 +1,13 @@
+# the contents of this file is going to be inserted into the extracted
+# repository https://github.com/kthohr/gcem so that this becomes a dependency
+# Bazel targets can depend on
+package(default_visibility = ["//visibility:public"])
+
+# one has to inspect the third-party library to understand what build metadata needs to be created;
+# gcem happens to be a header-only library (https://en.wikipedia.org/wiki/Header-only)
+cc_library(
+    name = "gcem",
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = ["include"],
+    strip_include_prefix = "include",
+)


### PR DESCRIPTION
With `http_archive` repository rule, a release of the GitHub project https://github.com/kthohr/gcem/ is downloaded and then extracted into an output directory at build time. This is useful when a project is not built with Bazel is not available on BCR. An existing BUILD file is inserted into the right location so that Bazel "thinks" this is just another directory with a Bazel package and build targets.