### PR TITLE
bazel: add genrule to generate a header file at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,4 @@ build:
 	bazel run //:gazelle
 	bazel run //src/apps:main -- 3 4
 	bazel run //src/apps:math -- 1
+	bazel run //src/apps:genheader

--- a/generated/BUILD.bazel
+++ b/generated/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+genrule(
+    name = "header-generated-genrule",
+    outs = ["header-generated.hpp"],
+    cmd = "echo 'void x();' > $@",
+)
+
+cc_library(
+    name = "header-generated-lib",
+    srcs = ["lib.cc"],
+    hdrs = ["header-generated.hpp"],
+    visibility = ["//visibility:public"],
+)

--- a/generated/lib.cc
+++ b/generated/lib.cc
@@ -1,0 +1,4 @@
+#include "generated/header-generated.hpp"
+#include <iostream>
+
+void x() { std::cout << 42; }

--- a/src/apps/BUILD.bazel
+++ b/src/apps/BUILD.bazel
@@ -16,3 +16,11 @@ cc_binary(
         "@gcem",
     ],
 )
+
+cc_binary(
+    name = "genheader",
+    srcs = ["genheader.cc"],
+    deps = [
+        "//generated:header-generated-lib",
+    ],
+)

--- a/src/apps/genheader.cc
+++ b/src/apps/genheader.cc
@@ -1,0 +1,3 @@
+#include "generated/header-generated.hpp"
+
+int main() { x(); }


### PR DESCRIPTION
It is possible to generate a header file using a `genrule`. Based on https://kchodorow.com/2016/05/19/using-a-generated-header-file-as-a-dependecy/.

