### PR TITLE
bazel: add uber's hermetic c++ toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,9 @@ common --verbose_failures
 # common --enable_platform_specific_config
 
 # https://bazel.build/reference/command-line-reference#build-flag--sandbox_add_mount_pair
-common --sandbox_add_mount_pair=/tmp/zig-cache
+common:hermetic-linux-amd64 --sandbox_add_mount_pair=/tmp/zig-cache
 # https://bazel.build/reference/command-line-reference#build-flag--sandbox_writable_path
-common --sandbox_writable_path=/tmp/zig-cache
+common:hermetic-linux-amd64 --sandbox_writable_path=/tmp/zig-cache
 
 test --test_output=all
 test --test_summary=detailed
@@ -17,7 +17,6 @@ test --test_summary=detailed
 # common --incompatible_enable_cc_toolchain_resolution
 # common --incompatible_use_cc_configure_from_rules_cc
 
-# setting these
 build:hermetic-linux-amd64 --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:hermetic-linux-amd64 --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,27 @@
 common --cxxopt=-std=c++17
+common --verbose_failures
+
+# https://bazel.build/reference/command-line-reference#common_options-flag--enable_platform_specific_config
+# this is to avoid adding "--config=linux" to the command
+# common --enable_platform_specific_config
+
+# https://bazel.build/reference/command-line-reference#build-flag--sandbox_add_mount_pair
+common --sandbox_add_mount_pair=/tmp/zig-cache
+# https://bazel.build/reference/command-line-reference#build-flag--sandbox_writable_path
+common --sandbox_writable_path=/tmp/zig-cache
 
 test --test_output=all
 test --test_summary=detailed
+
+# unclear what is the purpose of these in this context
+# common --incompatible_enable_cc_toolchain_resolution
+# common --incompatible_use_cc_configure_from_rules_cc
+
+# setting these
+build:hermetic-linux-amd64 --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:hermetic-linux-amd64 --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build:hermetic-linux-amd64 --platforms @zig_sdk//platform:linux_amd64
+# the toolchain name must match to what is being registered in MODULE.bazel with `register_toolchains()`;
+# attempting to use a not registered toolchain is bound to fail
+build:hermetic-linux-amd64 --extra_toolchains="@zig_sdk//toolchain:linux_amd64_gnu.2.31"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,6 +34,8 @@ toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolcha
 # )
 use_repo(toolchains, "zig_sdk")
 
-register_toolchains(
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.31",
-)
+# do not register the toolchain here, but instead pass it on the command
+# line using the `--extra_toolchains` flag
+# register_toolchains(
+#     "@zig_sdk//toolchain:linux_amd64_gnu.2.31",
+# )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "hermetic_cc_toolchain", version = "4.0.0")
 bazel_dep(name = "googletest", version = "1.16.0")  # gtest
 bazel_dep(name = "catch2", version = "3.8.1")
 
@@ -21,4 +22,18 @@ http_archive(
     sha256 = "8e71a9f5b62956da6c409dda44b483f98c4a98ae72184f3aa4659ae5b3462e61",
     strip_prefix = "gcem-1.18.0",
     urls = ["https://github.com/kthohr/gcem/archive/v1.18.0.tar.gz"],
+)
+
+toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+
+# cannot use this due to an error
+# Error in remove: trying to mutate a frozen list value
+# toolchains.exec_platform(
+#     os = "linux",
+#     arch = "amd64",
+# )
+use_repo(toolchains, "zig_sdk")
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_gnu.2.31",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -56,6 +56,8 @@
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
     "https://bcr.bazel.build/modules/googletest/1.16.0/MODULE.bazel": "a175623c69e94fca4ca7acbc12031e637b0c489318cd4805606981d4d7adb34a",
     "https://bcr.bazel.build/modules/googletest/1.16.0/source.json": "dd011b202542efcd4c0e3df34b1558d41598c6f287846728315ded5f7984b77a",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.0/MODULE.bazel": "22d77d653e6ce121fa87435388775517afbf271e441cb1efac948c0aae6c760d",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.0/source.json": "8ecd6d45071e85362a6a01b1442e54068d894f358690adc7fd76dafce7980972",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # geocpp
 
 A computational geometry project written in C++ and built with Bazel.
+
+## Build
+
+Using https://github.com/uber/hermetic_cc_toolchain:
+
+```
+$ bazel test \
+    --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
+    --toolchain_resolution_debug=".*" \
+    --config=hermetic-linux-amd64 \
+    --test_tag_filters="static" \
+    //...
+```

--- a/test/defs.bzl
+++ b/test/defs.bzl
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+def cc_test_custom(name, srcs, deps, linkstatic):
+    for mode in linkstatic:
+        cc_test(
+            name = name + "-linkstatic-" + str(mode),
+            srcs = srcs,
+            deps = deps,
+            linkstatic = mode,
+            tags = ["static" if mode else "dynamic"],
+        )

--- a/test/geometry/BUILD.bazel
+++ b/test/geometry/BUILD.bazel
@@ -1,17 +1,31 @@
-load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("//:test/defs.bzl", "cc_test_custom")
 
-cc_test(
+# The test targets built with a hermetic toolchain results in creation of test binaries
+# that are linked to some shared libraries in the `bazel-out` directories; they fail to
+# run with the `bazel test` command:
+#
+# rectangle-catch2-test: error while loading shared libraries: bazel-out/k8-fastbuild/
+# bin/_solib_k8/libsrc_Sgeometry_Slibrectangle.so: cannot open shared object file: No such file or directory
+#
+# To be able to run them with `bazel test` command, user libraries are linked statically
+# (if a static version is available), but system libraries (excluding C/C++ runtime libraries)
+# are linked dynamically. To have both test targets (statically and dynamically linked),
+# a simple macro is used to generate two identical targets with a different linking type and a tag.
+
+cc_test_custom(
     name = "rectangle-gtest-test",
     srcs = ["rectangle_gtest_test.cc"],
+    linkstatic = (True, False),
     deps = [
         "//src/geometry:rectangle",
         "@googletest//:gtest_main",
     ],
 )
 
-cc_test(
+cc_test_custom(
     name = "rectangle-catch2-test",
     srcs = ["rectangle_catch2_test.cc"],
+    linkstatic = (True, False),
     deps = [
         "//src/geometry:rectangle",
         "@catch2//:catch2_main",


### PR DESCRIPTION
Using https://github.com/uber/hermetic_cc_toolchain to build c++ code hermetically without having access to a local c++ toolchain.

Run

```
$ bazel build --toolchain_resolution_debug=".*" --config=hermetic-linux-amd64 //...
```

to see the toolchain resolution process and to build all targets for linux-amd64, hermetically.

Using a particular glibc:

```
$ ldd --version
ldd (Ubuntu GLIBC 2.31-0ubuntu9.17) 2.31
```

---

Building all targets (including test targets) works fine and one can even run the test binaries:

```
$ bazel-bin/test/geometry/rectangle-gtest-test                                     
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from RectangleTest
[ RUN      ] RectangleTest.GetRectangleArea
[       OK ] RectangleTest.GetRectangleArea (0 ms)
[ RUN      ] RectangleTest.GetRectangleAreaIfIsASquare
[       OK ] RectangleTest.GetRectangleAreaIfIsASquare (0 ms)
[----------] 2 tests from RectangleTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
```

however, the `test` command fails when run via the `bazel test`:

```
$ bazel test --toolchain_resolution_debug=".*" --config=hermetic-linux-amd64 //...
==================== Test output for //test/geometry:rectangle-gtest-test:
/home/user/.cache/bazel/_bazel_homeuser/51966dc905d3201ed8d44fb4278efba7/sandbox/linux-sandbox/1252/execroot/_main/bazel-out/k8-fastbuild/bin/test/geometry/rectangle-gtest-test.runfiles/_main/test/geometry/rectangle-gtest-test: error while loading shared libraries: bazel-out/k8-fastbuild/bin/_solib_k8/libsrc_Sgeometry_Slibrectangle.so: cannot open shared object file: No such file or directory
```

This is resolved by linking the test targets statically, see https://bazel.build/reference/be/c-cpp#cc_test