### PR TITLE
bazel: add support for builds in Docker

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,3 +24,16 @@ build:hermetic-linux-amd64 --platforms @zig_sdk//platform:linux_amd64
 # the toolchain name must match to what is being registered in MODULE.bazel with `register_toolchains()`;
 # attempting to use a not registered toolchain is bound to fail
 build:hermetic-linux-amd64 --extra_toolchains="@zig_sdk//toolchain:linux_amd64_gnu.2.31"
+
+# build CMake projects in a Docker container (for foreign_cc rule)
+common:docker-cmake --platforms=//platforms:docker-cmake
+common:docker-cmake --spawn_strategy=docker
+common:docker-cmake --experimental_enable_docker_sandbox
+common:docker-cmake --experimental_docker_image="cmake-build-env:latest"
+
+# for ensuring the host's toolchain is not being used 
+# (debian:stable-slim won't have any C++ compilers)
+common:docker-debian --platforms=//platforms:docker-debian
+common:docker-debian --spawn_strategy=docker
+common:docker-debian --experimental_enable_docker_sandbox
+common:docker-debian --experimental_docker_image="debian:stable-slim"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,11 +3,16 @@ module(
     repo_name = "geocpp",
 )
 
+# Bazel specific
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "hermetic_cc_toolchain", version = "4.0.0")
+
+# Third-party packages
 bazel_dep(name = "googletest", version = "1.16.0")  # gtest
 bazel_dep(name = "catch2", version = "3.8.1")
 
+# Dev dependencies
 bazel_dep(name = "gazelle", version = "0.42.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -62,7 +62,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
@@ -337,22 +338,6 @@
             "bazel_tools"
           ]
         ]
-      }
-    },
-    "@@platforms//host:extension.bzl%host_platform": {
-      "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "SeQiIN/f8/Qt9vYQk7qcXp4I4wJeEC0RnQDiaaJ4tb8=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "host_platform": {
-            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {

--- a/README.md
+++ b/README.md
@@ -4,13 +4,36 @@ A computational geometry project written in C++ and built with Bazel.
 
 ## Build
 
-Using https://github.com/uber/hermetic_cc_toolchain:
+### `uber/hermetic_cc_toolchain`
 
-```
+Using https://github.com/uber/hermetic_cc_toolchain.
+
+On host.
+
+```shell
 $ bazel test \
     --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
     --toolchain_resolution_debug=".*" \
     --config=hermetic-linux-amd64 \
+    --test_tag_filters="static" \
+    //...
+```
+
+In a Docker container; note multiple uses of `--config` that are accumulated.
+
+```shell
+# debian:stable-slim won't have any c++ compilers, but hermetic toolchain
+# should still succeed as it's going to bring everything with itself
+bazel test \
+    --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
+    --config=hermetic-linux-amd64 \
+    --config=docker-debian \
+    --test_tag_filters="static" \
+    //...
+
+# this will fail because there's no GCC compiler in the Docker image
+bazel test \
+    --config=docker-debian \
     --test_tag_filters="static" \
     //...
 ```

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -1,0 +1,24 @@
+# To support spawning actions in a Docker container
+platform(
+    name = "docker-cmake",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    exec_properties = {
+        "container-image": "docker://docker.io/cmake-build-env:latest",
+    },
+    tags = ["platform-docker"],
+)
+
+platform(
+    name = "docker-debian",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    exec_properties = {
+        "container-image": "docker://docker.io/debian:stable-slim",
+    },
+    tags = ["platform-docker"],
+)

--- a/platforms/advanced/Dockerfile
+++ b/platforms/advanced/Dockerfile
@@ -1,0 +1,14 @@
+# Use the latest LTS version of Ubuntu as base
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install required packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*

--- a/platforms/basic/Dockerfile
+++ b/platforms/basic/Dockerfile
@@ -1,0 +1,1 @@
+FROM debian:stable-slim


### PR DESCRIPTION
Add support to execute actions inside a Docker container. Demonstrate that using a hermetic toolchain doesn't access any local tooling such as compilers/linkers which is done by using a minimal Docker image.