### PR TITLE
ci: validate arm64 binary in a Docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,4 +111,4 @@ jobs:
         - name: Run binary in an arm64 Docker container
           run: |
             chmod +x ./bin/math-arm64
-            docker run --rm -v "$PWD/bin:/app" --platform linux/arm64 ubuntu bash -c "file /app/math-arm64 && /app/math-arm64 1"
+            docker run --rm -v "$PWD/bin:/app" --platform linux/arm64 ubuntu bash -c "/app/math-arm64 1"


### PR DESCRIPTION
Confirm that a binary executable produced using a hermetic toolchain when cross-compiling (building an arm64 binary on x86_64) can be run in a Docker container using QEMU emulation.