### PR TITLE
bazel: add support for LLVM toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,3 +55,9 @@ common:docker-debian --platforms=//platforms:docker-debian
 common:docker-debian --spawn_strategy=docker
 common:docker-debian --experimental_enable_docker_sandbox
 common:docker-debian --experimental_docker_image="debian:stable-slim"
+
+# for spawning some actions in a Docker container
+common:docker-container --platforms=//platforms:docker-container
+common:docker-container --spawn_strategy=docker
+common:docker-container --experimental_enable_docker_sandbox
+common:docker-container --experimental_docker_image="docker-container-build-env:latest"

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,9 @@ test --test_summary=detailed
 
 # the toolchain name in `--extra_toolchains` must match to what is being registered in 
 # MODULE.bazel with `register_toolchains()`; attempting to use a not registered toolchain 
-# is bound to fail
+# is bound to fail;
+# to get a list of available platforms (as they named slightly different in every toolchain), 
+# run `bazel query @zig_sdk//platform:all` and `bazel query @toolchains_llvm//platforms:all` 
 build:hermetic-linux-amd64 --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:hermetic-linux-amd64 --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:hermetic-linux-amd64 --platforms @zig_sdk//platform:linux_amd64
@@ -29,6 +31,17 @@ build:hermetic-linux-arm64 --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:hermetic-linux-arm64 --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:hermetic-linux-arm64 --platforms @zig_sdk//platform:linux_arm64
 build:hermetic-linux-arm64 --extra_toolchains="@zig_sdk//toolchain:linux_arm64_gnu.2.31"
+
+build:hermetic-linux-amd64-llvm --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:hermetic-linux-amd64-llvm --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:hermetic-linux-amd64-llvm --platforms @toolchains_llvm//platforms:linux-x86_64
+build:hermetic-linux-amd64-llvm --extra_toolchains="@llvm_toolchain//:cc-toolchain-x86_64-linux"
+
+# TODO: does not seem to have a toolchain "@llvm_toolchain//:cc-toolchain-aarch64-linux"?
+# build:hermetic-linux-arm64-llvm --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+# build:hermetic-linux-arm64-llvm --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+# build:hermetic-linux-arm64-llvm --platforms @toolchains_llvm//platforms:linux-aarch64
+# build:hermetic-linux-arm64-llvm --extra_toolchains="@llvm_toolchain//:cc-toolchain-x86_64-linux"
 
 # build CMake projects in a Docker container (for foreign_cc rule)
 common:docker-cmake --platforms=//platforms:docker-cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Lint
         # run clang-format without modifying the files and treat any formatting 
         # discrepancies as errors, causing the command to return a non-zero exit code
-        run: bazel run //:clang-format -- --dry-run -Werror **/*.cc **/*.hpp
+        run: |
+          docker build -t docker-container-build-env -f platforms/advanced/Dockerfile --load .
+          bazel run --config="docker-container" //:clang-format -- --dry-run -Werror **/*.cc **/*.hpp
 
   build-hermetic:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,11 @@ jobs:
         # run clang-format without modifying the files and treat any formatting 
         # discrepancies as errors, causing the command to return a non-zero exit code
         run: |
-          docker build -t docker-container-build-env -f platforms/advanced/Dockerfile --load .
-          bazel run --config="docker-container" //:clang-format -- --dry-run -Werror **/*.cc **/*.hpp
+          # running build actions in a sandbox does not seem to be supported by toolchains_llvm
+          # docker build -t docker-container-build-env -f platforms/advanced/Dockerfile --load .
+          wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          bazel run //:clang-format -- --dry-run -Werror **/*.cc **/*.hpp
 
   build-hermetic:
     runs-on: ubuntu-24.04
@@ -96,6 +99,8 @@ jobs:
 
       - name: Build ${{ matrix.arch }}
         run: |
+          wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
           bazel build \
             --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
             --config=hermetic-linux-${{ matrix.arch }}-llvm \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Test
         run: bazel test //...
 
+      - name: Lint
+        # run clang-format without modifying the files and treat any formatting 
+        # discrepancies as errors, causing the command to return a non-zero exit code
+        run: bazel run //:clang-format -- --dry-run -Werror **/*.cc **/*.hpp
+
   build-hermetic:
     runs-on: ubuntu-24.04
 
@@ -67,7 +72,33 @@ jobs:
         with:
           name: math-arm64
           path: dist/math-arm64
-          
+
+  build-hermetic-llvm:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        # TODO: add arm64 
+        arch: [amd64,]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+
+      - name: Build ${{ matrix.arch }}
+        run: |
+          bazel build \
+            --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
+            --config=hermetic-linux-${{ matrix.arch }}-llvm \
+            //src/apps:math         
+
   test-hermetic:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           # running build actions in a sandbox does not seem to be supported by toolchains_llvm
           # docker build -t docker-container-build-env -f platforms/advanced/Dockerfile --load .
           wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-          dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
           bazel run //:clang-format -- --dry-run -Werror **/*.cc **/*.hpp
 
   build-hermetic:
@@ -100,7 +100,7 @@ jobs:
       - name: Build ${{ matrix.arch }}
         run: |
           wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-          dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
           bazel build \
             --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
             --config=hermetic-linux-${{ matrix.arch }}-llvm \

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,3 +8,11 @@ buildifier(
 )
 
 gazelle(name = "gazelle")
+
+genrule(
+    name = "clang_format",
+    srcs = ["@llvm_toolchain//:bin/clang-format"],
+    outs = ["clang-format"],
+    cmd = "cat $< > $@",
+    executable = True,
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,6 +25,16 @@ git_override(
     remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
 )
 
+# Configure and register the toolchain.
+bazel_dep(name = "toolchains_llvm", version = "1.4.0")
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(llvm_version = "16.0.0")
+use_repo(llvm, "llvm_toolchain")
+# do not register the toolchain here, but instead pass it on the command
+# line using the `--extra_toolchains` flag
+# register_toolchains("@llvm_toolchain//:all")
+
 # Add direct HTTP archive dependency on a library that is not built with Bazel
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -161,6 +161,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
     "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.4.0/MODULE.bazel": "05239402b7374293359c2f22806f420b75aa5d6f4b15a2eaa809a2c214d58b31",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.4.0/source.json": "229a516d282b17a82be54c6e3ae220a1b750fb55a8495567e5c7a9d09423f3e2",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
@@ -400,6 +402,83 @@
             "rules_kotlin+",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
+      "general": {
+        "bzlTransitiveDigest": "miE+G1r8txiL9GGIOFLiY+RyielXfNO9OiFlFw+NE+U=",
+        "usagesDigest": "Y1/5fMiGhxDwFqXxwaAcjIH7/8s4shiFBTjiBZ3tAa4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm_toolchain_llvm": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
+            "attributes": {
+              "alternative_llvm_sources": [],
+              "auth_patterns": {},
+              "distribution": "auto",
+              "exec_arch": "",
+              "exec_os": "",
+              "libclang_rt": {},
+              "llvm_mirror": "",
+              "llvm_version": "16.0.0",
+              "llvm_versions": {},
+              "netrc": "",
+              "sha256": {},
+              "strip_prefix": {},
+              "urls": {}
+            }
+          },
+          "llvm_toolchain": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
+            "attributes": {
+              "absolute_paths": false,
+              "archive_flags": {},
+              "compile_flags": {},
+              "conly_flags": {},
+              "coverage_compile_flags": {},
+              "coverage_link_flags": {},
+              "cxx_builtin_include_directories": {},
+              "cxx_flags": {},
+              "cxx_standard": {},
+              "dbg_compile_flags": {},
+              "exec_arch": "",
+              "exec_os": "",
+              "extra_exec_compatible_with": {},
+              "extra_target_compatible_with": {},
+              "link_flags": {},
+              "link_libs": {},
+              "llvm_versions": {
+                "": "16.0.0"
+              },
+              "opt_compile_flags": {},
+              "opt_link_flags": {},
+              "stdlib": {},
+              "target_settings": {},
+              "unfiltered_compile_flags": {},
+              "toolchain_roots": {},
+              "sysroot": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "toolchains_llvm+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "toolchains_llvm+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "toolchains_llvm+",
+            "toolchains_llvm",
+            "toolchains_llvm+"
           ]
         ]
       }

--- a/README.md
+++ b/README.md
@@ -109,3 +109,25 @@ bazel run @hedron_compile_commands//:refresh_all
 ```
 
 This lets the IDE to understand the source code of a Bazel project.
+
+## Run clang tools
+
+Depending on the runtime environment, you might need to install `libinfo5`:
+
+```
+wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+```
+
+If arguments can be passed to a `native_binary`, then `native_binary` could be used
+
+```
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+native_binary(
+    name = "clang_format",
+    src = "@llvm_toolchain//:bin/clang-format",
+    out = "clang_format",
+)
+```
+
+Otherwise, a `genrule` can be used.

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -23,7 +23,6 @@ platform(
     tags = ["platform-docker"],
 )
 
-
 platform(
     name = "docker-debian",
     constraint_values = [

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -12,6 +12,19 @@ platform(
 )
 
 platform(
+    name = "docker-container",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    exec_properties = {
+        "container-image": "docker://docker.io/docker-container-build-env:latest",
+    },
+    tags = ["platform-docker"],
+)
+
+
+platform(
     name = "docker-debian",
     constraint_values = [
         "@platforms//cpu:x86_64",

--- a/platforms/advanced/Dockerfile
+++ b/platforms/advanced/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest LTS version of Ubuntu as base
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -7,8 +7,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Update and install required packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    wget \
     build-essential \
     cmake \
     git \
     ca-certificates && \
+    # required by clang tooling
+    wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
+    dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add support for https://github.com/bazel-contrib/toolchains_llvm.