### PR TITLE
bazel: run topiary formatter with rules_multitool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
           PYTHONUNBUFFERED: 1
         run: bazel run //tools:archiver
 
+      - name: Topiary
+        run: bazel run @multitool//tools/topiary:workspace_root -- format tools/multitool.lock.json
+
   lint-host:
     runs-on: ubuntu-24.04
 

--- a/.topiary/languages.ncl
+++ b/.topiary/languages.ncl
@@ -1,0 +1,15 @@
+{
+  languages = {
+    json = {
+      extensions = [
+        "json",
+      ],
+      indent = "  ",
+      grammar.source.git = {
+        git = "https://github.com/tree-sitter/tree-sitter-json.git",
+        rev = "v0.24.8",
+        nixHash = "sha256-DNZC2cTy1C8OaMOpEHM6NoRtOIbLaBf0CLXXWCKODlw=",
+      },
+    },
+  }
+}

--- a/README.md
+++ b/README.md
@@ -141,3 +141,11 @@ $ bazel build //:archive-lean
 $ tar -O -xf bazel-bin/archive.tar LICENSE
 $ tar -O -xf bazel-bin/archive-lean.tar LICENSE
 ```
+
+## Run topiary
+
+The configuration file is picked up automatically from the `.topiary` directory.
+
+```shell
+$ bazel run @multitool//tools/topiary:workspace_root -- format tools/multitool.lock.json
+```

--- a/tools/multitool.lock.json
+++ b/tools/multitool.lock.json
@@ -22,5 +22,18 @@
         "cpu": "x86_64"
       }
     ]
+  },
+  "topiary": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "file": "topiary-cli-x86_64-unknown-linux-gnu/topiary",
+        "type": "tar.xz",
+        "url": "https://github.com/tweag/topiary/releases/download/v0.6.1/topiary-cli-x86_64-unknown-linux-gnu.tar.xz",
+        "sha256": "0e92b430dfd3aa0cc5033579fd546f9df9a66117888ed526c61b95fe58b2c9a1",
+        "os": "linux",
+        "cpu": "x86_64"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Add support to run `topiary` via `rules_multitool`.