### PR TITLE
bazel: push Docker image to Docker registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,36 @@ jobs:
         run: |
           docker run --rm release:latest 14 3
 
+  push-docker-registry:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # from https://github.com/bazel-contrib/setup-bazel
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Share build cache between workflows.
+          disk-cache: true
+          # Share repository cache between workflows.
+          repository-cache: true
+
+      - name: Set up Docker registry
+        run: |
+          docker run -d -p 5000:5000 --name registry registry:2
+
+      - name: Create and load Docker image
+        run: |
+          bazel run //containers:image_push
+
+      - name: List registry images
+        run: |
+          curl http://localhost:5000/v2/apps/cpp/tags/list
+
   test-arm64-emulated:
       name: run-arm64-binary-docker 
       needs: build-hermetic

--- a/containers/BUILD.bazel
+++ b/containers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@tar.bzl", "tar")
 
 package(default_visibility = ["//visibility:public"])
@@ -23,4 +23,11 @@ oci_load(
     name = "image_load",
     image = ":image",
     repo_tags = ["release:latest"],
+)
+
+oci_push(
+    name = "image_push",
+    image = ":image",
+    remote_tags = ["0.0.1"],
+    repository = "localhost:5000/apps/cpp",
 )


### PR DESCRIPTION
Push a Docker image with a compiled C++ application into a local Docker registry using https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md