### PR TITLE
bazel: add depend_on_what_you_use aspect

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,11 @@ jobs:
           # Share repository cache between workflows.
           repository-cache: true
 
+      - name: bazel-dwyu
+        run: |
+          bazel build --aspects=//tools:aspect.bzl%your_dwyu_aspect --output_groups=dwyu //... || true
+          bazel run @depend_on_what_you_use//:apply_fixes -- --fix-all --dry-run
+
       - name: clang-format
         # run clang-format without modifying the files and treat any formatting
         # discrepancies as errors, causing the command to return a non-zero exit code

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,13 @@ bazel_dep(name = "catch2", version = "3.8.1")
 bazel_dep(name = "gazelle", version = "0.42.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)
 
+bazel_dep(name = "depend_on_what_you_use", version = "0.9.0")
+git_override(
+    module_name = "depend_on_what_you_use",
+    commit = "1d2476671a70578c4713e7dc40dd15b5bf671c4d",
+    remote = "https://github.com/martis42/depend_on_what_you_use",
+)
+
 bazel_dep(name = "rules_multitool", version = "1.5.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "tar.bzl", version = "0.3.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -77,6 +77,8 @@
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
+    "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
@@ -121,6 +123,7 @@
     "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
     "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
@@ -165,6 +168,7 @@
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
+    "https://bcr.bazel.build/modules/rules_python/0.37.2/MODULE.bazel": "b5ffde91410745750b6c13be1c5dc4555ef5bc50562af4a89fd77807fdde626a",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
     "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
@@ -186,6 +190,7 @@
     "https://bcr.bazel.build/modules/toolchains_llvm/1.4.0/MODULE.bazel": "05239402b7374293359c2f22806f420b75aa5d6f4b15a2eaa809a2c214d58b31",
     "https://bcr.bazel.build/modules/toolchains_llvm/1.4.0/source.json": "229a516d282b17a82be54c6e3ae220a1b750fb55a8495567e5c7a9d09423f3e2",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
@@ -358,6 +363,38 @@
           ],
           [
             "buildifier_prebuilt+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@depend_on_what_you_use+//third_party:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "RjZck2uOD3yOE5gkbgpbt4zL35e6KQiID6onPns/Hmk=",
+        "usagesDigest": "Ua+z8YLLNY1h/6qgupV7wuAoHQJbIGIE4W9E1zcyxW4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "dwyu_pcpp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5af9fbce55f136d7931ae915fae03c34030a3b36c496e72d9636cedc8e2543a1",
+              "strip_prefix": "pcpp-1.30",
+              "build_file": "@@depend_on_what_you_use+//third_party/pcpp:pcpp.BUILD",
+              "urls": [
+                "https://files.pythonhosted.org/packages/41/07/876153f611f2c610bdb8f706a5ab560d888c938ea9ea65ed18c374a9014a/pcpp-1.30.tar.gz"
+              ],
+              "patches": [
+                "@@depend_on_what_you_use+//third_party/pcpp:recursion_fix.patch"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "depend_on_what_you_use+",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/src/geometry/BUILD.bazel
+++ b/src/geometry/BUILD.bazel
@@ -4,8 +4,9 @@ cc_library(
     name = "rectangle",
     srcs = ["rectangle.cc"],
     hdrs = ["include/rectangle.hpp"],
-    #https: // bazel.build/tutorials/cpp-use-cases#add-include-paths
-    #show how to store headers in a separate directory to exercise copts
-    copts = ["-Isrc/geometry/include"],
+    # https://bazel.build/tutorials/cpp-use-cases#add-include-paths
+    # show how to store headers in a separate directory to exercise copts;
+    # with `copts = ["-Isrc/geometry/include"]`, no need for `strip_include_prefix`
+    strip_include_prefix = "include",
     visibility = ["//visibility:public"],
 )

--- a/test/geometry/BUILD.bazel
+++ b/test/geometry/BUILD.bazel
@@ -18,6 +18,7 @@ cc_test_custom(
     linkstatic = (True, False),
     deps = [
         "//src/geometry:rectangle",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )
@@ -28,6 +29,7 @@ cc_test_custom(
     linkstatic = (True, False),
     deps = [
         "//src/geometry:rectangle",
+        "@catch2",
         "@catch2//:catch2_main",
     ],
 )

--- a/tools/aspect.bzl
+++ b/tools/aspect.bzl
@@ -1,0 +1,3 @@
+load("@depend_on_what_you_use//:defs.bzl", "dwyu_aspect_factory")
+
+your_dwyu_aspect = dwyu_aspect_factory()


### PR DESCRIPTION
Add support for https://github.com/martis42/depend_on_what_you_use

```
$ bazel build --aspects=//tools:aspect.bzl%your_dwyu_aspect --output_groups=dwyu //...
```

produces report 

```
$ cat bazel-out/k8-fastbuild/bin/src/geometry/rectangle_dwyu_report.json                                                 
{
  "analyzed_target": "@@//src/geometry:rectangle",
  "public_includes_without_dep": {},
  "private_includes_without_dep": {
    "src/geometry/rectangle.cc": [
      "rectangle.hpp"
    ]
  },
  "unused_deps": [],
  "unused_implementation_deps": [],
  "deps_which_should_be_private": [],
  "use_implementation_deps": false
}
```

and now fix these:

```
$ bazel run @depend_on_what_you_use//:apply_fixes -- --fix-all --dry-run
```

Note https://github.com/martis42/depend_on_what_you_use/issues/376