### PR TITLE
bazel: add include_on_what_you_use via multitool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,11 @@ jobs:
           bazel build --aspects=//tools:aspect.bzl%your_dwyu_aspect --output_groups=dwyu //... || true
           bazel run @depend_on_what_you_use//:apply_fixes -- --fix-all --dry-run
 
+      - name: bazel-iwyu
+        run: |
+          bazel run --run_under="cd $(bazel info workspace) &&" @multitool//tools/iwyu -- \
+            -I src/geometry/include src/geometry/rectangle.cc
+
       - name: clang-format
         # run clang-format without modifying the files and treat any formatting
         # discrepancies as errors, causing the command to return a non-zero exit code

--- a/tools/multitool.lock.json
+++ b/tools/multitool.lock.json
@@ -10,5 +10,17 @@
         "cpu": "x86_64"
       }
     ]
+  },
+  "iwyu": {
+    "binaries": [
+      {
+        "file": "iwyu-0.20-x86_64-linux-gnu/bin/include-what-you-use",
+        "kind": "archive",
+        "url": "https://github.com/storypku/bazel_iwyu/releases/download/0.20/iwyu-0.20-x86_64-linux-gnu.tar.xz",
+        "sha256": "684e3e7193d6a8ee77ed485c0378f64e8c13f8a30c0709545d13c8c1655811c5",
+        "os": "linux",
+        "cpu": "x86_64"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Include https://include-what-you-use.org/ via a static binary.