### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bazel"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add support for bumping Bazel dependencies in MODULE.bazel now that Dependabot supports it: https://github.com/dependabot/dependabot-core/issues/2196